### PR TITLE
feat(aws_profile): Allowing AWS Profile for local execution runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+## Should not be committed to the repository as its generated locally and has Account ID's etc. 
+*.csv

--- a/main.go
+++ b/main.go
@@ -28,21 +28,26 @@ func main() {
 	userConfig := parseFlags()
 
 	// Setup CSV Logger
-	csvLogger, err := logger.NewCSVLogger("aws-resource-discovery.csv")
+	csvLogger, err := logger.NewCSVLogger("aws-resource-discovery.csv", userConfig.Profile)
 	if err != nil {
 		log.Fatalf("Failed to initialize CSV logger: %v", err)
 	}
 	defer csvLogger.Close()
 
-	// Load the AWS SDK configuration
-	cfg, err := aws_config.LoadDefaultConfig(ctx)
+	// Load the AWS SDK configuration with profile if set
+	var cfg aws.Config
+	if userConfig.Profile != "" {
+		cfg, err = aws_config.LoadDefaultConfig(ctx, aws_config.WithSharedConfigProfile(userConfig.Profile))
+	} else {
+		cfg, err = aws_config.LoadDefaultConfig(ctx)
+	}
 	if err != nil {
 		log.Fatalf("Failed to load AWS configuration: %v", err)
 	}
 
 	// Create STS Client
 	stsClient := sts.NewFromConfig(cfg)
-	credsManager := managers.NewCredentialsManager(userConfig.RoleName, stsClient)
+	credsManager := managers.NewCredentialsManager(userConfig.RoleName, stsClient, userConfig.Profile, userConfig.Debug)
 	sessionManager := managers.NewSessionManager(stsClient)
 
 	// Create EC2 Client
@@ -124,6 +129,8 @@ func parseFlags() config.Config {
 	flag.StringVar(&config.RoleName, "AWS_ROLE_NAME", "", "AWS Role Name")
 	flag.BoolVar(&config.Trail, "AWS_TRAIL", false, "Set to true to print CloudTrail information")
 	flag.StringVar(&excludeAccounts, "EXCLUDE", "", "Comma-separated list of AWS account numbers to exclude")
+	flag.StringVar(&config.Profile, "AWS_PROFILE", "", "AWS profile name to use for credentials")
+	flag.BoolVar(&config.Debug, "DEBUG", false, "Enable debug logging")
 
 	// Parse flags
 	flag.Parse()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,4 +8,6 @@ type Config struct {
 	RoleName        string
 	Trail           bool
 	ExcludeAccounts []string
+	Profile         string
+	Debug           bool
 }

--- a/pkg/logger/csv_logger.go
+++ b/pkg/logger/csv_logger.go
@@ -8,18 +8,19 @@ import (
 )
 
 type csvLogger struct {
-	file   *os.File
-	writer *csv.Writer
+	file    *os.File
+	writer  *csv.Writer
+	profile string
 }
 
-func NewCSVLogger(filename string) (interfaces.Logger, error) {
+func NewCSVLogger(filename string, profile string) (interfaces.Logger, error) {
 	file, err := os.Create(filename)
 	if err != nil {
 		return nil, err
 	}
 
 	writer := csv.NewWriter(file)
-	return &csvLogger{file: file, writer: writer}, nil
+	return &csvLogger{file: file, writer: writer, profile: profile}, nil
 }
 
 func (l *csvLogger) Log(record []string) error {
@@ -33,6 +34,10 @@ func (l *csvLogger) Log(record []string) error {
 
 func (l *csvLogger) Logf(format string, args ...interface{}) error {
 	record := fmt.Sprintf(format, args...)
+	if l.profile != "" {
+		fmt.Fprintln(os.Stderr, record)
+		return nil
+	}
 	return l.Log([]string{record})
 }
 

--- a/pkg/logger/csv_logger_test.go
+++ b/pkg/logger/csv_logger_test.go
@@ -14,7 +14,7 @@ func TestNewCSVLogger(t *testing.T) {
 	filename := "test_csv_logger.csv"
 	defer os.Remove(filename)
 
-	logger, err := logger.NewCSVLogger(filename)
+	logger, err := logger.NewCSVLogger(filename, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, logger)
 
@@ -30,7 +30,7 @@ func TestCSVLogger_Log(t *testing.T) {
 	filename := "test_csv_logger.csv"
 	defer os.Remove(filename)
 
-	logger, err := logger.NewCSVLogger(filename)
+	logger, err := logger.NewCSVLogger(filename, "")
 	assert.NoError(t, err)
 	defer logger.Close()
 
@@ -51,7 +51,7 @@ func TestCSVLogger_Logf(t *testing.T) {
 	filename := "test_csv_logger.csv"
 	defer os.Remove(filename)
 
-	logger, err := logger.NewCSVLogger(filename)
+	logger, err := logger.NewCSVLogger(filename, "")
 	assert.NoError(t, err)
 	defer logger.Close()
 

--- a/pkg/managers/credential_manager.go
+++ b/pkg/managers/credential_manager.go
@@ -6,18 +6,23 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 type credentialsManager struct {
 	awsRoleName string
 	stsClient   interfaces.STSClient
+	profile     string
+	debug       bool
 }
 
-func NewCredentialsManager(roleName string, stsClient interfaces.STSClient) interfaces.CredentialsManager {
+func NewCredentialsManager(roleName string, stsClient interfaces.STSClient, profile string, debug bool) interfaces.CredentialsManager {
 	return &credentialsManager{
 		awsRoleName: roleName,
 		stsClient:   stsClient,
+		profile:     profile,
+		debug:       debug,
 	}
 }
 
@@ -36,8 +41,29 @@ func (cm *credentialsManager) createAssumeRoleInput(accountId, region string) *s
 }
 
 func (cm *credentialsManager) CredentialsFor(ctx context.Context, accountId, region string) (aws.Credentials, error) {
+	if cm.profile != "" {
+		if cm.debug {
+			fmt.Println("\n[DEBUG] Using AWS profile:", cm.profile)
+		}
+		if cm.debug {
+			cfg, err := config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(cm.profile))
+			if err == nil {
+				creds, err := cfg.Credentials.Retrieve(ctx)
+				if err == nil {
+					fmt.Printf("[DEBUG] SDK loaded access key: %s\n", creds.AccessKeyID)
+				} else {
+					fmt.Printf("[DEBUG] Could not retrieve credentials from SDK: %v\n", err)
+				}
+			} else {
+				fmt.Printf("[DEBUG] Could not load AWS SDK config: %v\n", err)
+			}
+		}
+		return aws.Credentials{}, nil
+	}
+	if cm.debug {
+		fmt.Println("\n[DEBUG] No profile set, attempting to AssumeRole via STS")
+	}
 	input := cm.createAssumeRoleInput(accountId, region)
-
 	assumeRoleOutput, err := cm.stsClient.AssumeRole(ctx, input)
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("failed to assume role: %w", err)

--- a/pkg/managers/credential_manager_test.go
+++ b/pkg/managers/credential_manager_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCredentialsManager_CredentialsFor(t *testing.T) {
 	mockSTSClient := new(mocks.MockSTSClient)
-	manager := NewCredentialsManager("test-role", mockSTSClient).(*credentialsManager)
+	manager := NewCredentialsManager("test-role", mockSTSClient, "").(*credentialsManager)
 
 	ctx := context.Background()
 	accountId := "123456789012"
@@ -52,7 +52,7 @@ func TestCredentialsManager_CredentialsFor(t *testing.T) {
 
 func TestCredentialsManager_CredentialsFor_Error(t *testing.T) {
 	mockSTSClient := new(mocks.MockSTSClient)
-	manager := NewCredentialsManager("test-role", mockSTSClient).(*credentialsManager)
+	manager := NewCredentialsManager("test-role", mockSTSClient, "").(*credentialsManager)
 
 	ctx := context.TODO()
 	accountId := "123456789012"
@@ -77,7 +77,7 @@ func TestCredentialsManager_CredentialsFor_Error(t *testing.T) {
 }
 
 func TestCredentialsManager_createAssumeRoleInput(t *testing.T) {
-	manager := NewCredentialsManager("test-role", nil).(*credentialsManager)
+	manager := NewCredentialsManager("test-role", nil, "").(*credentialsManager)
 
 	accountId := "123456789012"
 	region := "us-east-1"
@@ -91,7 +91,7 @@ func TestCredentialsManager_createAssumeRoleInput(t *testing.T) {
 }
 
 func TestCredentialsManager_awsRoleArn(t *testing.T) {
-	manager := NewCredentialsManager("test-role", nil).(*credentialsManager)
+	manager := NewCredentialsManager("test-role", nil, "").(*credentialsManager)
 
 	accountId := "123456789012"
 	expectedRoleArn := "arn:aws:iam::123456789012:role/test-role"
@@ -99,7 +99,7 @@ func TestCredentialsManager_awsRoleArn(t *testing.T) {
 
 	assert.Equal(t, expectedRoleArn, roleArn)
 
-	manager = NewCredentialsManager("", nil).(*credentialsManager)
+	manager = NewCredentialsManager("", nil, "").(*credentialsManager)
 	roleArn = manager.awsRoleArn(accountId)
 	assert.Equal(t, "", roleArn)
 }

--- a/pkg/managers/session_manager.go
+++ b/pkg/managers/session_manager.go
@@ -65,7 +65,21 @@ func (sm *sessionManager) AssumeRoleIfNeeded(ctx context.Context, cfg aws.Config
 }
 
 func (sm *sessionManager) InitializeSessionAndCredentials(ctx context.Context, config config.Config, logger interfaces.Logger) (aws.Config, aws.Credentials) {
-	cfg, err := aws_conf.LoadDefaultConfig(ctx, aws_conf.WithRegion(config.Region))
+	var cfg aws.Config
+	var err error
+	if config.Profile != "" {
+		cfg, err = aws_conf.LoadDefaultConfig(ctx,
+			aws_conf.WithRegion(config.Region),
+			aws_conf.WithSharedConfigProfile(config.Profile),
+		)
+		if err != nil {
+			logger.Logf("Failed to load AWS config: %v", err)
+			return aws.Config{}, aws.Credentials{}
+		}
+		return cfg, aws.Credentials{}
+	}
+
+	cfg, err = aws_conf.LoadDefaultConfig(ctx, aws_conf.WithRegion(config.Region))
 	if err != nil {
 		logger.Logf("Failed to load AWS config: %v", err)
 		return aws.Config{}, aws.Credentials{}

--- a/pkg/scanner/org_scanner.go
+++ b/pkg/scanner/org_scanner.go
@@ -18,6 +18,7 @@ type OrgScanner struct {
 	Regions            []string
 	STSClient          interfaces.STSClient
 	OrgClient          interfaces.OrganizationsClient
+	Profile            string
 	ScannerFactory     func(accountId, region string, credentials aws.Credentials, logger interfaces.Logger, totals *interfaces.ResourceTotals) ResourceScannerInterface
 }
 
@@ -28,7 +29,6 @@ type ResourceScannerInterface interface {
 func (s *OrgScanner) Call() {
 	totals := interfaces.ResourceTotals{}
 	progress := newProgressReporter(len(s.OrgAccounts), len(s.Regions))
-
 	for _, account := range s.OrgAccounts {
 		for _, region := range s.Regions {
 			progress.report()

--- a/pkg/scanner/resource_scanner.go
+++ b/pkg/scanner/resource_scanner.go
@@ -20,6 +20,7 @@ import (
 
 type ResourceScanner struct {
 	Session     aws.Config
+	Profile     string
 	Credentials aws.Credentials
 	AccountId   string
 	Region      string
@@ -74,16 +75,25 @@ func (s *ResourceScanner) scanResources() {
 	}
 
 	resourceResults := make(map[string]int)
+	var hadError bool
 
 	for range counters {
 		result := <-results
+		if result.Error != nil {
+			hadError = true
+			s.Logger.Logf("[ERROR] %s: %v", result.CounterClass, result.Error)
+		}
 		resourceResults[result.CounterClass] = result.Count
 		s.updateTotals(result.CounterClass, result.Count)
 	}
 
-	for resourceType, resourceCount := range resourceResults {
-		record := []string{s.AccountId, s.Region, resourceType, strconv.Itoa(resourceCount)}
-		s.Logger.Log(record)
+	if !hadError {
+		for resourceType, resourceCount := range resourceResults {
+			record := []string{s.AccountId, s.Region, resourceType, strconv.Itoa(resourceCount)}
+			s.Logger.Log(record)
+		}
+	} else {
+		s.Logger.Logf("[ERROR] One or more resource counters failed, resource counts not output.")
 	}
 }
 
@@ -92,7 +102,16 @@ func (s *ResourceScanner) createSession(ctx context.Context) aws.Config {
 		return s.Session
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(s.Region))
+	var cfg aws.Config
+	var err error
+	if s.Profile != "" {
+		cfg, err = config.LoadDefaultConfig(ctx,
+			config.WithRegion(s.Region),
+			config.WithSharedConfigProfile(s.Profile),
+		)
+	} else {
+		cfg, err = config.LoadDefaultConfig(ctx, config.WithRegion(s.Region))
+	}
 	if err != nil {
 		s.Logger.Logf("Failed to initialize AWS session: %v", err)
 	}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -65,7 +65,7 @@ func (s *Scanner) initializeScan(ctx context.Context, config config.Config) (aws
 	return cfg, initialCredentials, regions, nil
 }
 
-func (s *Scanner) initializeOrgScanner(cfg aws.Config, orgAccounts []types.Account, regions []string) *OrgScanner {
+func (s *Scanner) initializeOrgScanner(cfg aws.Config, orgAccounts []types.Account, regions []string, profile string) *OrgScanner {
 	orgClient := s.OrgClientFactory(cfg)
 	if orgClient == nil {
 		log.Printf("OrgClient is nil")
@@ -78,6 +78,7 @@ func (s *Scanner) initializeOrgScanner(cfg aws.Config, orgAccounts []types.Accou
 		Regions:            regions,
 		STSClient:          s.STSClient,
 		OrgClient:          orgClient,
+		Profile:            profile,
 		ScannerFactory: func(accountId, region string, credentials aws.Credentials, logger interfaces.Logger, totals *interfaces.ResourceTotals) ResourceScannerInterface {
 			return &ResourceScanner{
 				AccountId:   accountId,
@@ -85,13 +86,14 @@ func (s *Scanner) initializeOrgScanner(cfg aws.Config, orgAccounts []types.Accou
 				Credentials: credentials,
 				Logger:      logger,
 				Totals:      totals,
+				Profile:     profile,
 			}
 		},
 	}
 }
 
 func (s *Scanner) performScan(cfg aws.Config, initialCredentials aws.Credentials, regions []string, orgAccounts []types.Account, config config.Config) (ScanResult, error) {
-	orgScanner := s.initializeOrgScanner(cfg, orgAccounts, regions)
+	orgScanner := s.initializeOrgScanner(cfg, orgAccounts, regions, config.Profile)
 	if orgScanner == nil {
 		log.Printf("Failed to initialize org scanner")
 		return ScanResult{}, fmt.Errorf("failed to initialize org scanner")


### PR DESCRIPTION
Adding some features / changes to the binary for those whom dont wish to run it in a cloudshell environment. 

- Adding a Gitignore to ensure no local CSV files are committed to the repo during local executions for those wishing to contribute. 


## Flag Changes ##
- Adding a Debug flag to denote access key and profile for debugging purposes and allowing others to  explicitly write things out with a flag. 
- Adding AWS_PROFILE as a flag to allow local execution.


## Behaviour changes ##
When AWS_PROFILE flag is passed it will no longer log the errors into the CSV, instead outputting it into the terminal. 
```
go run main.go --AWS_ACCOUNT_ID="x" --AWS_TRAIL="false" --AWS_REGION="x" --AWS_PROFILE="x"
Single account scan selected.
2025/07/30 10:54:40 Error counting AWS::EC2::Volume: operation error CloudControl: ListResources, https response error StatusCode: 0, RequestID: , request send failed, Post "https://cloudcontrolapi.x.amazonaws.com/": dial tcp: lookup cloudcontrolapi.x.amazonaws.com: no such host
```

When AWS_PROFILE flag is passed it will no longer attempt to assume the red-canary role as it should be able to use supplied credentials. 

when DEBUG Flag is passed in it will log the Access KEYID to the terminal
```
go run main.go --AWS_ACCOUNT_ID="X" --AWS_TRAIL="false" --AWS_REGION="X" --AWS_PROFILE="X" --DEBUG
Single account scan selected.
Red Canary - AWS Resource Discovery Scan Progress: 1 / 1 ...
[DEBUG] Using AWS profile: X
[DEBUG] SDK loaded access key: X
```